### PR TITLE
Add Clap Parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ path = "src/lib/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.3.0", features = ["derive"] }
 num-traits = "0.2.15"

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,11 +1,13 @@
+use clap::Parser;
 use num_traits::PrimInt;
 pub mod fizz_buzz_result;
-use fizz_buzz_result::FizzBuzzResult::{*, self};
-use std::{ops::Range, io::Write};
+use fizz_buzz_result::FizzBuzzResult::{self, *};
+use std::{io::Write, ops::Range};
 
 pub fn fizz_type<T>(num: T) -> FizzBuzzResult<T>
 where
-T: PrimInt {
+    T: PrimInt,
+{
     let zero = T::zero();
     let three = T::from(3).expect("Failure converting 3");
     let five = T::from(5).expect("Failure converting 5");
@@ -13,7 +15,7 @@ T: PrimInt {
         (a, b) if a == zero && b == zero => FizzBuzz,
         (a, _) if a == zero => Fizz,
         (_, a) if a == zero => Buzz,
-        (_, _) => Number(num)
+        (_, _) => Number(num),
     }
 }
 
@@ -22,4 +24,10 @@ pub fn write_range<W: Write>(mut w: W, r: Range<usize>) -> std::io::Result<()> {
         writeln!(w, "{}", fizz_type(i))?;
     }
     Ok(())
+}
+
+#[derive(Parser)]
+pub struct Arguments {
+    #[clap(default_value = "100")]
+    pub end: usize,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
+use clap::Parser;
 use fizzbuzzlib::*;
 
 fn main() -> std::io::Result<()> {
-    write_range(std::io::stdout().lock(), 1..101)
+    write_range(std::io::stdout().lock(), 1..Arguments::parse().end)
 }


### PR DESCRIPTION
Binary is literally unusable (does not take in inputs).
Fixed that (barely). Currently means that inputs from the binary are only allowed to be usize because genericising this over NumTraits was very hard.